### PR TITLE
Implement RunSimulation engine and trade tracking

### DIFF
--- a/go/engine/backtest.go
+++ b/go/engine/backtest.go
@@ -4,22 +4,44 @@ import (
 	"trading-bot/types"
 )
 
-func simulateTicker(ticker string, data []types.Bar) []types.Trade {
-	var tradesForTicker []types.Trade
-	var inPosition bool
-	var buyPrice float64
+func RunSimulation(data []types.Bar, strat types.Strategy) []types.Trade {
+	var results []types.Trade
+	var activeTrade *types.Trade
+	var history []types.Bar
 
-	//kollar så vi har nog med SMA data (100)
-	for i, tick := range data {
-		if i < 100 {
-			continue
+	strategyName := strat.Name()
+
+	for _, bar := range data {
+		if activeTrade != nil {
+			if bar.Low <= activeTrade.StopLoss || bar.High >= activeTrade.Target {
+				activeTrade.ClosePrice = bar.Close
+				if activeTrade.Action == "BUY" {
+					activeTrade.ProfitLoss = activeTrade.ClosePrice - activeTrade.EntryPrice
+				} else if activeTrade.Action == "SELL" {
+					activeTrade.ProfitLoss = activeTrade.EntryPrice - activeTrade.ClosePrice
+				}
+				results = append(results, *activeTrade)
+				activeTrade = nil
+			}
+		}
+
+		history = append(history, bar)
+		if len(history) > 200 //måste inte vara 200 {
+			history = history[1:]
+		}
+		if activeTrade == nil {
+			signal := strat.OnBar(bar, history)
+
+			if signal.Action == "BUY" || signal.Action == "SELL" {
+				activeTrade = &types.Trade{
+					StrategyName: strategyName,
+					Action:       signal.Action,
+					EntryPrice:   bar.Close,
+					StopLoss:     signal.StopLoss,
+					Target:       signal.Target,
+				}
+			}
 		}
 	}
-
-	sma := calculateSMA(data[i-100 : i])
-	//read data
-	//loop over time
-	//MATH functions
-
-	return tradesForTicker
+	return results
 }

--- a/go/types/models.go
+++ b/go/types/models.go
@@ -1,10 +1,21 @@
 package types
 
 type Trade struct {
-	Timestamp  int64   `parquet:"timestamp"`
-	Symbol     string  `parquet:"symbol"`
-	Action     string  `parquet:"action"`
-	Price      float64 `parquet:"price"`
+	StrategyName string `parquet:"strategy_name"` //"FVG_Trend"
+	Symbol       string `parquet:"symbol"`        //"BTCUSDT"
+	Action       string `parquet:"action"`        // "BUY" "SELL"
+
+	// Time Stamps
+	EntryTime int64 `parquet:"entry_time"`
+	CloseTime int64 `parquet:"close_time"`
+
+	// Price levels
+	EntryPrice float64 `parquet:"entry_price"`
+	ClosePrice float64 `parquet:"close_price"`
+	StopLoss   float64 `parquet:"stop_loss"`
+	Target     float64 `parquet:"target"`
+
+	// Result
 	ProfitLoss float64 `parquet:"profit_loss"`
 }
 

--- a/go/types/strategy_types.go
+++ b/go/types/strategy_types.go
@@ -1,0 +1,7 @@
+package types
+
+// every file with functions are part of Startegy (fvg, LIQ, cross)
+type Strategy interface {
+	Name() string
+	OnBar(bar Bar, history []Bar) Signal
+}


### PR DESCRIPTION
- Add logic to open, monitor, and close trades based on SL/TP
- Calculate absolute Profit/Loss for both BUY and SELL actions
- Optimize memory usage by capping the history slice to 200 bars
- Connect the engine to the new Strategy interface